### PR TITLE
[Client] fix / mobile blocking socker

### DIFF
--- a/client/src/shared/hooks/use-responsive/index.ts
+++ b/client/src/shared/hooks/use-responsive/index.ts
@@ -9,7 +9,7 @@ interface Store {
 }
 
 const useStore = create<Store>(() => ({
-  viewportType: 'desktop',
+  viewportType: 'mobile',
   isInitialized: false,
 }));
 


### PR DESCRIPTION
https://github.com/ryxxn/ryooniverse/issues/18

## 문제 상황

useResponsive에서 viewport의 초기값이 `desktop`으로 설정되어 있었음.  
그래서 `initialized`되기 전에 맵 화면이 잠시 로드됨에 따라 소켓이 연결됨.

## 해결 방안

viewport type의 초기값을 `mobile`로 변경한다.
